### PR TITLE
Can specify root directory when loading model

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -36,7 +36,7 @@ _MODELS = {
 }
 
 
-def _download(url: str, root: str = os.path.expanduser("~/.cache/clip")):
+def _download(url: str, root: str):
     os.makedirs(root, exist_ok=True)
     filename = os.path.basename(url)
 
@@ -83,7 +83,7 @@ def available_models() -> List[str]:
     return list(_MODELS.keys())
 
 
-def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_available() else "cpu", jit: bool = False, **kwargs: Any):
+def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_available() else "cpu", jit: bool = False, download_root: str = None):
     """Load a CLIP model
 
     Parameters
@@ -97,8 +97,8 @@ def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_a
     jit : bool
         Whether to load the optimized JIT model or more hackable non-JIT model (default).
 
-    **kwargs (optional): Any
-        The corresponding kwargs for internal `_download` function.
+    download_root: str
+        path to download the model files; by default, it uses "~/.cache/clip"
 
     Returns
     -------
@@ -109,7 +109,7 @@ def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_a
         A torchvision transform that converts a PIL image into a tensor that the returned model can take as its input
     """
     if name in _MODELS:
-        model_path = _download(_MODELS[name], **kwargs)
+        model_path = _download(_MODELS[name], download_root or os.path.expanduser("~/.cache/clip"))
     elif os.path.isfile(name):
         model_path = name
     else:

--- a/clip/clip.py
+++ b/clip/clip.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 import urllib
 import warnings
-from typing import Union, List
+from typing import Any, Union, List
 
 import torch
 from PIL import Image
@@ -83,7 +83,7 @@ def available_models() -> List[str]:
     return list(_MODELS.keys())
 
 
-def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_available() else "cpu", jit=False):
+def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_available() else "cpu", jit: bool = False, **kwargs: Any):
     """Load a CLIP model
 
     Parameters
@@ -97,6 +97,9 @@ def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_a
     jit : bool
         Whether to load the optimized JIT model or more hackable non-JIT model (default).
 
+    **kwargs (optional): Any
+        The corresponding kwargs for internal `_download` function.
+
     Returns
     -------
     model : torch.nn.Module
@@ -106,7 +109,7 @@ def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_a
         A torchvision transform that converts a PIL image into a tensor that the returned model can take as its input
     """
     if name in _MODELS:
-        model_path = _download(_MODELS[name])
+        model_path = _download(_MODELS[name], **kwargs)
     elif os.path.isfile(name):
         model_path = name
     else:


### PR DESCRIPTION
The `clip.load()` function did not have any option to specify the `root` directory used in the internal `_download()` function.

This PR add keywords args to the function which allow the user to specify a custom cache directory.

Example:
```py
import clip

model = clip.load("ViT-B/32", root="/path/to/cache")
```