### PR TITLE
Fix PyTorch version check

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -19,7 +19,7 @@ except ImportError:
     BICUBIC = Image.BICUBIC
 
 
-if [int(n) for n in torch.__version__.split(".")] < [1, 7, 1]:
+if [int(n.split("+")[0]) for n in torch.__version__.split(".")] < [1, 7, 1]:
     warnings.warn("PyTorch version 1.7.1 or higher is recommended")
 
 

--- a/clip/clip.py
+++ b/clip/clip.py
@@ -19,7 +19,7 @@ except ImportError:
     BICUBIC = Image.BICUBIC
 
 
-if torch.__version__.split(".") < ["1", "7", "1"]:
+if [int(n) for n in torch.__version__.split(".")] < [1, 7, 1]:
     warnings.warn("PyTorch version 1.7.1 or higher is recommended")
 
 


### PR DESCRIPTION
So the check works fine with PyTorch 1.10.0.