### PR TITLE
Fixes #169: Compare version using integers

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -19,7 +19,7 @@ except ImportError:
     BICUBIC = Image.BICUBIC
 
 
-if torch.__version__.split(".") < ["1", "7", "1"]:
+if [int(v) for v in torch.__version__.split(".")] < [1, 7, 1]:
     warnings.warn("PyTorch version 1.7.1 or higher is recommended")
 
 


### PR DESCRIPTION
pytorch version 1.10 has been released and this causes the version check
to erroneously fail. This fixes that comparison.

````
>>> [1, 10, 0] < [1, 7, 1]
False
>>> ["1", "10", "0"] < ["1", "7", "1"]
True
```