### PR TITLE
use `pkg_resources` for PyTorch version comparison

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -3,6 +3,7 @@ import os
 import urllib
 import warnings
 from typing import Any, Union, List
+from pkg_resources import packaging
 
 import torch
 from PIL import Image
@@ -19,7 +20,7 @@ except ImportError:
     BICUBIC = Image.BICUBIC
 
 
-if [int(n.split("+")[0]) for n in torch.__version__.split(".")[:3]] < [1, 7, 1]:
+if packaging.version.parse(torch.__version__) < packaging.version.parse("1.7.1"):
     warnings.warn("PyTorch version 1.7.1 or higher is recommended")
 
 


### PR DESCRIPTION
Use `pkg_resources` from `setuptools` to parse version strings, it is required by Pytorch >= 0.4.1 anyway.
Compatible with `TorchVersion`.

Examples: `1.9.0a0+2ecb2c7` `1.10.0.dev20210803+cu111` `1.10.0+cu111`