### PR TITLE
use pkg_resources for PyTorch version checks in notebooks

### DIFF
--- a/notebooks/Interacting_with_CLIP.ipynb
+++ b/notebooks/Interacting_with_CLIP.ipynb
@@ -352,10 +352,11 @@
       "source": [
         "import numpy as np\n",
         "import torch\n",
+        "from pkg_resources import packaging\n",
         "\n",
         "print(\"Torch version:\", torch.__version__)\n",
         "\n",
-        "assert torch.__version__.split(\".\") >= [\"1\", \"7\", \"1\"], \"PyTorch 1.7.1 or later is required\""
+        "assert packaging.version.parse(torch.__version__) >= packaging.version.parse(\"1.7.1\"), \"PyTorch 1.7.1 or later is required\""
       ],
       "execution_count": 2,
       "outputs": [

--- a/notebooks/Interacting_with_CLIP.ipynb
+++ b/notebooks/Interacting_with_CLIP.ipynb
@@ -354,9 +354,7 @@
         "import torch\n",
         "from pkg_resources import packaging\n",
         "\n",
-        "print(\"Torch version:\", torch.__version__)\n",
-        "\n",
-        "assert packaging.version.parse(torch.__version__) >= packaging.version.parse(\"1.7.1\"), \"PyTorch 1.7.1 or later is required\""
+        "print(\"Torch version:\", torch.__version__)\n"
       ],
       "execution_count": 2,
       "outputs": [

--- a/notebooks/Prompt_Engineering_for_ImageNet.ipynb
+++ b/notebooks/Prompt_Engineering_for_ImageNet.ipynb
@@ -590,9 +590,7 @@
         "from tqdm.notebook import tqdm\n",
         "from pkg_resources import packaging\n",
         "\n",
-        "print(\"Torch version:\", torch.__version__)\n",
-        "\n",
-        "assert packaging.version.parse(torch.__version__) >= packaging.version.parse(\"1.7.1\"), \"PyTorch 1.7.1 or later is required\""
+        "print(\"Torch version:\", torch.__version__)\n"
       ],
       "execution_count": 2,
       "outputs": [

--- a/notebooks/Prompt_Engineering_for_ImageNet.ipynb
+++ b/notebooks/Prompt_Engineering_for_ImageNet.ipynb
@@ -588,10 +588,11 @@
         "import torch\n",
         "import clip\n",
         "from tqdm.notebook import tqdm\n",
+        "from pkg_resources import packaging\n",
         "\n",
         "print(\"Torch version:\", torch.__version__)\n",
         "\n",
-        "assert torch.__version__.split(\".\") >= [\"1\", \"7\", \"1\"], \"PyTorch 1.7.1 or later is required\""
+        "assert packaging.version.parse(torch.__version__) >= packaging.version.parse(\"1.7.1\"), \"PyTorch 1.7.1 or later is required\""
       ],
       "execution_count": 2,
       "outputs": [


### PR DESCRIPTION
Followup to #173 and #176, makes the notebooks work out of the box in Colab