### PR TITLE
add setter for dtype

### DIFF
--- a/clip/model.py
+++ b/clip/model.py
@@ -296,6 +296,7 @@ class CLIP(nn.Module):
         self.logit_scale = nn.Parameter(torch.ones([]) * np.log(1 / 0.07))
 
         self.initialize_parameters()
+        self._dtype = self.visual.conv1.weight.dtype
 
     def initialize_parameters(self):
         nn.init.normal_(self.token_embedding.weight, std=0.02)
@@ -336,7 +337,11 @@ class CLIP(nn.Module):
 
     @property
     def dtype(self):
-        return self.visual.conv1.weight.dtype
+        return self._dtype
+    
+    @dtype.setter
+    def dtype(self, value):
+        self._dtype = value
 
     def encode_image(self, image):
         return self.visual(image.type(self.dtype))


### PR DESCRIPTION
Sometimes, we would like to just use the text encoder by removing the visual model, e.g., 
```python
model, _ = clip.load("ViT-B/32")
del model.visual  # keep the text encoder only
text_features = model.encode_text(text_tokens)
```
This will throw an error that `CLIP has no attribute self.dtype` because the dtype attr depends on the visual model part. Also, we cannot directly assign a new dtype to it because it is decorated by the `@property`.

So this PR aims to solve the above issue. With this PR, we can do
```python
model.dtype = ${new dtype} 
```
by adding a property setter for the attribute of dtype. 
