### PR TITLE
Add PyTorch Hub configuration file

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,42 @@
+from clip.clip import tokenize as _tokenize, load as _load, available_models as _available_models
+import re
+import string
+
+dependencies = ["torch", "torchvision", "ftfy", "regex", "tqdm"]
+
+# For compatibility (cannot include special characters in function name)
+model_functions = { model: re.sub(f'[{string.punctuation}]', '_', model) for model in _available_models()}
+
+def _create_hub_entrypoint(model):
+    def entrypoint(**kwargs):      
+        return _load(model, **kwargs)
+    
+    entrypoint.__doc__ = f"""Loads the {model} CLIP model
+
+        Parameters
+        ----------
+        device : Union[str, torch.device]
+            The device to put the loaded model
+
+        jit : bool
+            Whether to load the optimized JIT model or more hackable non-JIT model (default).
+
+        download_root: str
+            path to download the model files; by default, it uses "~/.cache/clip"
+
+        Returns
+        -------
+        model : torch.nn.Module
+            The {model} CLIP model
+
+        preprocess : Callable[[PIL.Image], torch.Tensor]
+            A torchvision transform that converts a PIL image into a tensor that the returned model can take as its input
+        """
+    return entrypoint
+
+def tokenize():
+    return _tokenize
+
+_entrypoints = {model_functions[model]: _create_hub_entrypoint(model) for model in _available_models()}
+
+globals().update(_entrypoints)


### PR DESCRIPTION
This PR aims to add support for PyTorch's hub loading feature. This would make model loading as simple as specifying this git repo to download the CLIP model along with its pre-trained weights. When working with `torch.hub.load`, the example would change from this

```py
import torch
import clip
from PIL import Image

device = "cuda" if torch.cuda.is_available() else "cpu"
model, preprocess = clip.load("ViT-B/32", device=device)

image = preprocess(Image.open("CLIP.png")).unsqueeze(0).to(device)
text = clip.tokenize(["a diagram", "a dog", "a cat"]).to(device)

with torch.no_grad():
    image_features = model.encode_image(image)
    text_features = model.encode_text(text)
    
    logits_per_image, logits_per_text = model(image, text)
    probs = logits_per_image.softmax(dim=-1).cpu().numpy()

print("Label probs:", probs)  # prints: [[0.9927937  0.00421068 0.00299572]]
```

to this 

```py
import torch
from PIL import Image

device = "cuda" if torch.cuda.is_available() else "cpu"
model, preprocess = torch.hub.load("openai/CLIP", "ViT_B_32", device=device)
tokenize = torch.hub.load("openai/CLIP", "tokenize")

image = preprocess(Image.open("CLIP.png")).unsqueeze(0).to(device)
text = tokenize(["a diagram", "a dog", "a cat"]).to(device)

with torch.no_grad():
    image_features = model.encode_image(image)
    text_features = model.encode_text(text)
    
    logits_per_image, logits_per_text = model(image, text)
    probs = logits_per_image.softmax(dim=-1).cpu().numpy()

print("Label probs:", probs)  # prints: [[0.9927937  0.00421068 0.00299572]]