### PR TITLE
Remove inefficient computation from `AttentionPool2d` Module

### DIFF
--- a/clip/model.py
+++ b/clip/model.py
@@ -66,7 +66,7 @@ class AttentionPool2d(nn.Module):
         self.num_heads = num_heads
 
     def forward(self, x):
-        x = x.reshape(x.shape[0], x.shape[1], x.shape[2] * x.shape[3]).permute(2, 0, 1)  # NCHW -> (HW)NC
+        x = x.flatten(start_dim=2).permute(2, 0, 1)  # NCHW -> (HW)NC
         x = torch.cat([x.mean(dim=0, keepdim=True), x], dim=0)  # (HW+1)NC
         x = x + self.positional_embedding[:, None, :].to(x.dtype)  # (HW+1)NC
         x, _ = F.multi_head_attention_forward(

--- a/clip/model.py
+++ b/clip/model.py
@@ -67,8 +67,8 @@ class AttentionPool2d(nn.Module):
 
     def forward(self, x):
         x = x.reshape(x.shape[0], x.shape[1], x.shape[2] * x.shape[3]).permute(2, 0, 1)  # NCHW -> (HW)NC
-        x = torch.cat([x.mean(dim=0, keepdim=True), x], dim=0)      # (HW+1)NC
-        x = x + self.positional_embedding[:, None, :].to(x.dtype)   # (HW+1)NC
+        x = torch.cat([x.mean(dim=0, keepdim=True), x], dim=0)  # (HW+1)NC
+        x = x + self.positional_embedding[:, None, :].to(x.dtype)  # (HW+1)NC
         x, _ = F.multi_head_attention_forward(
             query=x[:1], key=x, value=x,
             embed_dim_to_check=x.shape[-1],

--- a/clip/model.py
+++ b/clip/model.py
@@ -67,10 +67,10 @@ class AttentionPool2d(nn.Module):
 
     def forward(self, x):
         x = x.reshape(x.shape[0], x.shape[1], x.shape[2] * x.shape[3]).permute(2, 0, 1)  # NCHW -> (HW)NC
-        x = torch.cat([x.mean(dim=0, keepdim=True), x], dim=0)  # (HW+1)NC
-        x = x + self.positional_embedding[:, None, :].to(x.dtype)  # (HW+1)NC
+        x = torch.cat([x.mean(dim=0, keepdim=True), x], dim=0)      # (HW+1)NC
+        x = x + self.positional_embedding[:, None, :].to(x.dtype)   # (HW+1)NC
         x, _ = F.multi_head_attention_forward(
-            query=x, key=x, value=x,
+            query=x[:1], key=x, value=x,
             embed_dim_to_check=x.shape[-1],
             num_heads=self.num_heads,
             q_proj_weight=self.q_proj.weight,
@@ -88,8 +88,7 @@ class AttentionPool2d(nn.Module):
             training=self.training,
             need_weights=False
         )
-
-        return x[0]
+        return x.squeeze(0)
 
 
 class ModifiedResNet(nn.Module):


### PR DESCRIPTION
This is a simple fix that removes unnecessary attention computation from the `AttentionPool2d` Module.
In the existing version, self attention is calculated on the full spatial + average embedding sequence with shape `[(HW+1), N, C]`. In the proposed fix, attention is calculated with the average embedding `[1, N, C]` as the query and the spatial + average embedding sequence `[(HW+1), N, C]` as the key/value.

I created this gist: [https://gist.github.com/jenkspt/3a09cc150ab531781c6084c166047639](https://gist.github.com/jenkspt/3a09cc150ab531781c6084c166047639) to demonstrate the equivalence of the existing implementation and the proposed one. There is parity in both the computation and the parameter state -- so there shouldn't be any breaking changes introduced.

I realize that `AttentionPool2d` is only used once in the CLIP model, so this fix will not have a huge impact -- however I arrived here from  [https://github.com/openai/guided-diffusion/blob/main/guided_diffusion/unet.py#L22-L51](https://github.com/openai/guided-diffusion/blob/main/guided_diffusion/unet.py#L22-L51), which is based on the clip version (and has the same problem) -- so I think there is the added benefit for posterity

