### PR TITLE
Fixed the problem with torch.jit.script

### DIFF
--- a/clip/model.py
+++ b/clip/model.py
@@ -159,7 +159,8 @@ class LayerNorm(nn.LayerNorm):
 
     def forward(self, x: torch.Tensor):
         orig_type = x.dtype
-        ret = super(LayerNorm, self).forward(x.type(torch.float32))
+        ret = F.layer_norm(
+            x.type(torch.float32), self.normalized_shape, self.weight, self.bias, self.eps)
         return ret.type(orig_type)
 
 

--- a/clip/model.py
+++ b/clip/model.py
@@ -159,7 +159,7 @@ class LayerNorm(nn.LayerNorm):
 
     def forward(self, x: torch.Tensor):
         orig_type = x.dtype
-        ret = super().forward(x.type(torch.float32))
+        ret = super(LayerNorm).forward(x.type(torch.float32))
         return ret.type(orig_type)
 
 

--- a/clip/model.py
+++ b/clip/model.py
@@ -159,7 +159,7 @@ class LayerNorm(nn.LayerNorm):
 
     def forward(self, x: torch.Tensor):
         orig_type = x.dtype
-        ret = super(LayerNorm).forward(x.type(torch.float32))
+        ret = super(LayerNorm, self).forward(x.type(torch.float32))
         return ret.type(orig_type)
 
 


### PR DESCRIPTION
Because of the `LayerNorm` implementation, we cannot convert the plain model to a jit script. This PR fixes that. 