### PR TITLE
Accept `Sequence` instead of `List`

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -2,7 +2,7 @@ import hashlib
 import os
 import urllib
 import warnings
-from typing import Any, Union, List
+from typing import Any, Union, List, Sequence
 from pkg_resources import packaging
 
 import torch
@@ -194,7 +194,7 @@ def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_a
     return model, _transform(model.input_resolution.item())
 
 
-def tokenize(texts: Union[str, List[str]], context_length: int = 77, truncate: bool = False) -> Union[torch.IntTensor, torch.LongTensor]:
+def tokenize(texts: Union[str, Sequence[str]], context_length: int = 77, truncate: bool = False) -> Union[torch.IntTensor, torch.LongTensor]:
     """
     Returns the tokenized representation of given input string(s)
 


### PR DESCRIPTION
This is minor, I know. `tokenize` simply iterates over `texts`, so in addition to `list`, `tuple` is fine. The intended type hint for this is `Sequence`.

I am not sure which version of Python this project targets, but judging from the other type hints in this file, I am going to assume `<3.9`. Otherwise, I would suggest importing `Sequence` from `collections.abc` instead of `typing`.