### PR TITLE
Fix "AttributeError: module 'numpy' has no attribute 'float'" error in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ classifier.fit(train_features, train_labels)
 
 # Evaluate using the logistic regression classifier
 predictions = classifier.predict(test_features)
-accuracy = np.mean((test_labels == predictions).astype(np.float)) * 100.
+accuracy = np.mean((test_labels == predictions).astype(float)) * 100.
 print(f"Accuracy = {accuracy:.3f}")
 ```
 


### PR DESCRIPTION
`np.float` has been removed in `numpy` 1.24, which is just Python `float`. See https://stackoverflow.com/questions/74844262/how-to-solve-error-numpy-has-no-attribute-float-in-python