### PR TITLE
remove unnecessary cache in simple tokenizer

### DIFF
--- a/clip/simple_tokenizer.py
+++ b/clip/simple_tokenizer.py
@@ -7,7 +7,6 @@ import ftfy
 import regex as re
 
 
-@lru_cache()
 def default_bpe():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "bpe_simple_vocab_16e6.txt.gz")
 


### PR DESCRIPTION
The `default_bpe()` is called as default parameter in constructor of SimpleTokenizer. Since python's [function default parameters only execute once when the function definition is executed](https://docs.python.org/3.5/reference/compound_stmts.html#function-definitions), so there is no need to cache it, and the operation is not so expensive.