### PR TITLE
Add CLIP guide to See Also section

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,3 +197,4 @@ Note that the `C` value should be determined via a hyperparameter sweep using a 
 
 * [OpenCLIP](https://github.com/mlfoundations/open_clip): includes larger and independently trained CLIP models up to ViT-G/14
 * [Hugging Face implementation of CLIP](https://huggingface.co/docs/transformers/model_doc/clip): for easier integration with the HF ecosystem
+* [OpenAI's CLIP is the most important advancement in computer vision this year](https://blog.roboflow.com/openai-clip/): analysis of CLIP use cases in computer vision (Roboflow, 2021).


### PR DESCRIPTION
The Roboflow team are huge fans of CLIP. Team members have written guides on everything from [building semantic search engines](https://blog.roboflow.com/clip-semantic-search/) to [building web games using CLIP](https://blog.roboflow.com/how-we-built-paint-wtf-an-ai-that-judges-your-art-100-000-submissions/) (the web game received over 150,000 submissions when it went viral online).

Back when CLIP came out, @yeldarb wrote a guide introducing CLIP and its use cases, which we have since used as a canonical reference to show the capabilities of CLIP. I wanted to add it to the repository since the post helped me learn about CLIP when I was new to vision.