### PR TITLE
Fixed bugs when reading non-JIT model file

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -133,6 +133,7 @@ def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_a
             if jit:
                 warnings.warn(f"File {model_path} is not a JIT archive. Loading as a state dict instead")
                 jit = False
+            opened_file.seek(0) # If loading failed, reset file offset to the beginning
             state_dict = torch.load(opened_file, map_location="cpu")
 
     if not jit:


### PR DESCRIPTION
When reading non JIT model file, the file handler will move to somewhere in between the file. Causes "EOFError: Ran out of input" error. Resetting the offset may solve the issue. 