### PR TITLE
import packaging to be compatible with setuptools==70.0.0

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -3,7 +3,7 @@ import os
 import urllib
 import warnings
 from typing import Any, Union, List
-from pkg_resources import packaging
+import packaging
 
 import torch
 from PIL import Image

--- a/clip/clip.py
+++ b/clip/clip.py
@@ -2,8 +2,8 @@ import hashlib
 import os
 import urllib
 import warnings
-from typing import Any, Union, List
-import packaging
+from packaging import version
+from typing import Union, List
 
 import torch
 from PIL import Image
@@ -20,7 +20,7 @@ except ImportError:
     BICUBIC = Image.BICUBIC
 
 
-if packaging.version.parse(torch.__version__) < packaging.version.parse("1.7.1"):
+if version.parse(torch.__version__) < version.parse("1.7.1"):
     warnings.warn("PyTorch version 1.7.1 or higher is recommended")
 
 
@@ -228,7 +228,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77, truncate: b
     sot_token = _tokenizer.encoder["<|startoftext|>"]
     eot_token = _tokenizer.encoder["<|endoftext|>"]
     all_tokens = [[sot_token] + _tokenizer.encode(text) + [eot_token] for text in texts]
-    if packaging.version.parse(torch.__version__) < packaging.version.parse("1.8.0"):
+    if version.parse(torch.__version__) < version.parse("1.8.0"):
         result = torch.zeros(len(all_tokens), context_length, dtype=torch.long)
     else:
         result = torch.zeros(len(all_tokens), context_length, dtype=torch.int)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ftfy
+packaging
 regex
 tqdm
 torch


### PR DESCRIPTION
As described in Issue #446 (https://github.com/openai/CLIP/issues/446), there is a change from setuptools 70.0.0 which causes breaking behaviour. This change fixes this. However, it will force the usage of setuptools 70.0.0. 

In another PR, I've offered a solution which checks the version, which provides backward compatibility - #450 
```python
File ~/python3.12/site-packages/clip/clip.py:6
      5 from typing import Any, Union, List
----> 6 from pkg_resources import packaging
      8 import torch

ImportError: cannot import name 'packaging' from 'pkg_resources' (~/python3.12/site-packages/pkg_resources/__init__.py)
```