### PR TITLE
fix torch.load after torch.jit.load

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -133,6 +133,7 @@ def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_a
             if jit:
                 warnings.warn(f"File {model_path} is not a JIT archive. Loading as a state dict instead")
                 jit = False
+            opened_file.seek(0) # set the file pointer to the beginning of the file
             state_dict = torch.load(opened_file, map_location="cpu")
 
     if not jit:


### PR DESCRIPTION
If we try to load a CLIP model that has not been traced (and is saved as a state_dict), then this first tries to load it with `torch.jit.load(opened_file)`, which will raise a RuntimeError; this is then caught and you re-try loading the model with `torch.load(opened_file)`. However, the file pointer, `opened_file` has been advanced by `torch.jit.load`, so this attempt fails with a `EOFError: Ran out of input` exception. To fix this, we simply need to reset the file pointer to the beginning of the file with `.fseek(0)`