### PR TITLE
docs: Add Available Models table to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,24 @@ Returns the names of the available CLIP models.
 
 Returns the model and the TorchVision transform needed by the model, specified by the model name returned by `clip.available_models()`. It will download the model as necessary. The `name` argument can also be a path to a local checkpoint.
 
-The device to run the model can be optionally specified, and the default is to use the first CUDA device if there is any, otherwise the CPU. When `jit` is `False`, a non-JIT version of the model will be loaded.
+The device to run the model can be optionally specified. The default is to use the first CUDA device if available; otherwise, it uses the CPU. When `jit` is `False`, a non-JIT version of the model is loaded.
+
+
+### Available Models
+
+The following models are available for automatic download via `clip.load()`.
+
+| Model Name | Parameters | Description | Download Link |
+|:---|:---:|:---|:---|
+| `RN50` | ~38M | ResNet-50 | [Link](https://openaipublic.azureedge.net/clip/models/afeb0e10f9e5a86da6080e35cf09123aca3b358a0c3e3b6c78a7b63bc04b6762/RN50.pt) |
+| `RN101` | ~56M | ResNet-101 | [Link](https://openaipublic.azureedge.net/clip/models/8fa8567bab74a42d41c5915025a8e4538c3bdbe8804a470a72f30b0d94fab599/RN101.pt) |
+| `RN50x4` | ~87M | ResNet-50 scaled 4x | [Link](https://openaipublic.azureedge.net/clip/models/7e526bd135e493cef0776de27d5f42653e6b4c8bf9e0f653bb11773263205fdd/RN50x4.pt) |
+| `RN50x16` | ~167M | ResNet-50 scaled 16x | [Link](https://openaipublic.azureedge.net/clip/models/52378b407f34354e150460fe41077663dd5b39c54cd0bfd2b27167a4a06ec9aa/RN50x16.pt) |
+| `RN50x64` | ~420M | ResNet-50 scaled 64x | [Link](https://openaipublic.azureedge.net/clip/models/be1cfb55d75a9666199fb2206c106743da0f6468c9d327f3e0d0a543a9919d9c/RN50x64.pt) |
+| `ViT-B/32` | ~88M | Vision Transformer Base (32x32 patch) | [Link](https://openaipublic.azureedge.net/clip/models/40d365715913c9da98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt) |
+| `ViT-B/16` | ~86M | Vision Transformer Base (16x16 patch) | [Link](https://openaipublic.azureedge.net/clip/models/5806e77cd80f8b59890b7e101eabd078d9fb84e6937f9e85e4ecb61988df416f/ViT-B-16.pt) |
+| `ViT-L/14` | ~304M | Vision Transformer Large (14x14 patch) | [Link](https://openaipublic.azureedge.net/clip/models/b8cca3fd41ae0c99ba7e8951adf17d267cdb84cd88be6f7c2e0eca1737a03836/ViT-L-14.pt) |
+| `ViT-L/14@336px` | ~304M | ViT-L/14 with higher resolution (336px) | [Link](https://openaipublic.azureedge.net/clip/models/3035c92b350959924f9f00213499208652fc7ea050643e8b385c2dac08641f02/ViT-L-14-336px.pt) |
 
 #### `clip.tokenize(text: Union[str, List[str]], context_length=77)`
 


### PR DESCRIPTION
Adds a reference table in the Usage section listing all available CLIP models and their download links. Addresses #199.