### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
             pytorch-version: 1.10.1
             torchvision-version: 0.11.2
     steps:
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
       - run: conda install -n test python=${{ matrix.python-version }} pytorch=${{ matrix.pytorch-version }} torchvision=${{ matrix.torchvision-version }} cpuonly -c pytorch
       - uses: actions/checkout@v2
       - run: echo "$CONDA/envs/test/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `conda-incubator/setup-miniconda` | [`v2`](https://github.com/conda-incubator/setup-miniconda/releases/tag/v2) | [`v3`](https://github.com/conda-incubator/setup-miniconda/releases/tag/v3) | [Release](https://github.com/conda-incubator/setup-miniconda/releases/tag/v3) | test.yml |

## Breaking Changes

- **conda-incubator/setup-miniconda** (v2 → v3): Major version upgrade — review the [release notes](https://github.com/conda-incubator/setup-miniconda/releases) for breaking changes

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
