### PR TITLE
notebooks: remove deprecated pkg_resources imports

### DIFF
--- a/notebooks/Interacting_with_CLIP.ipynb
+++ b/notebooks/Interacting_with_CLIP.ipynb
@@ -352,7 +352,6 @@
       "source": [
         "import numpy as np\n",
         "import torch\n",
-        "from pkg_resources import packaging\n",
         "\n",
         "print(\"Torch version:\", torch.__version__)\n"
       ],

--- a/notebooks/Prompt_Engineering_for_ImageNet.ipynb
+++ b/notebooks/Prompt_Engineering_for_ImageNet.ipynb
@@ -588,7 +588,6 @@
         "import torch\n",
         "import clip\n",
         "from tqdm.notebook import tqdm\n",
-        "from pkg_resources import packaging\n",
         "\n",
         "print(\"Torch version:\", torch.__version__)\n"
       ],


### PR DESCRIPTION
## Summary
- remove unused pkg_resources imports from the example notebooks
- avoid notebook import failures in environments where pkg_resources is no longer available

## Testing
- not run (notebook import cleanup only)

Closes #528